### PR TITLE
Feature: Added a backward compatible version of '@dataclass'

### DIFF
--- a/src/AthenaLib/decorators/dataclass.py
+++ b/src/AthenaLib/decorators/dataclass.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import dataclasses
+import sys
+import typing
+
+
+_T = typing.TypeVar('_T')
+
+
+def dataclass(cls, **kwargs) -> typing.Callable[[typing.Type[_T]], typing.Type[_T]]:
+    if sys.version_info >= (3, 10):
+        return dataclasses.dataclass(cls, **kwargs)
+    else:
+        kwargs.pop('match_args', None)
+        kwargs.pop('slots', None)
+        kwargs.pop('kw_only', None)
+        return dataclasses.dataclass(cls, **kwargs)


### PR DESCRIPTION
Personally, I think this implementation is a bit lacking in features. It only removes the attributes, which could lead to unintended behavior in previous Python versions. But the other option would be to copy half of the Python3.10 `dataclasses` module to support the `slots` and the `kw_only` attributes, which doesn't seem optimal either (and potentially doesn't even work).

There is a third-party library which backports dataclasses: [dataclassy](https://pypi.org/project/dataclassy/)
But i know DirectiveAthena projects don't use much third-party libraries. It's just there to give an idea, how a full backport would look like.

If anything seems wrong or something should be added, just leave a comment.