### PR TITLE
Bugfix: Corrected imports

### DIFF
--- a/Tests/functions/test_class_from_method.py
+++ b/Tests/functions/test_class_from_method.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 # Custom Library
-from AthenaLib.functions import *
+from AthenaLib.functions import class_from_method
 
 # Custom Packages
 from Tests.test_structure import TestStructure

--- a/Tests/models/test_bezier.py
+++ b/Tests/models/test_bezier.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 # Custom Library
-from AthenaLib.models import *
+from AthenaLib.models.bezier import CubicBezier
 
 # Custom Packages
 from Tests.test_structure import TestStructure

--- a/Tests/models/test_degree.py
+++ b/Tests/models/test_degree.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 # Custom Library
-from AthenaLib.models import *
+from AthenaLib.models.degree import Degree
 
 # Custom Packages
 from Tests.test_structure import TestStructure

--- a/Tests/models/test_vectors.py
+++ b/Tests/models/test_vectors.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 # Custom Library
-from AthenaLib.models import *
+from AthenaLib.models.vectors import Vector1D
+from AthenaLib.models.vectors import Vector2D
+from AthenaLib.models.vectors import Vector3D
 
 # Custom Packages
 from Tests.test_structure import TestStructure


### PR DESCRIPTION
### Why?
following tests failed because they couldn't find the objects that should get tested:
- `test_class_from_method`
- `test_degree`
- `test_bezier`
- `test_vectors`

### What changed?
Corrected the imports.