### PR TITLE
Fixing AthenaLib.decorators.dataclass.dataclass and applying it

### DIFF
--- a/src/AthenaLib/HTML/models/css.py
+++ b/src/AthenaLib/HTML/models/css.py
@@ -4,7 +4,6 @@
 # General Packages
 from __future__ import annotations
 from typing import Any
-from dataclasses import dataclass
 
 # Custom Library
 from AthenaColor import HEX, RGB, RGBA
@@ -13,6 +12,7 @@ from AthenaColor import HEX, RGB, RGBA
 from AthenaLib.HTML.models.html import HTMLElement
 from AthenaLib.HTML.data.css_selection_type import CSSSelectionType
 from AthenaLib.data.text import NEW_LINE,NOTHING
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -

--- a/src/AthenaLib/HTML/models/html.py
+++ b/src/AthenaLib/HTML/models/html.py
@@ -4,7 +4,6 @@
 # General Packages
 from __future__ import annotations
 import copy
-from dataclasses import dataclass
 from typing import Any
 
 # Custom Library
@@ -12,6 +11,7 @@ from typing import Any
 # Custom Packages
 from AthenaLib.functions.string import enclose_double_quote
 from AthenaLib.functions.type_check import type_check_error
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -

--- a/src/AthenaLib/HTML/models/html_library.py
+++ b/src/AthenaLib/HTML/models/html_library.py
@@ -3,7 +3,6 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-from dataclasses import dataclass
 from typing import Any
 
 # Custom Library
@@ -12,6 +11,7 @@ from typing import Any
 from AthenaLib.HTML.models.html import HTMLElement
 from AthenaLib.functions.type_check import type_check_error
 from AthenaLib.functions.string import enclose_double_quote
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -

--- a/src/AthenaLib/HTML/models/html_library_unsupported_in_html_5.py
+++ b/src/AthenaLib/HTML/models/html_library_unsupported_in_html_5.py
@@ -3,13 +3,13 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-from dataclasses import dataclass
 
 # Custom Library
 
 # Custom Packages
 from AthenaLib.HTML.models.html import HTMLElement
 from AthenaLib.functions.type_check import type_check_error
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -

--- a/src/AthenaLib/decorators/dataclass.py
+++ b/src/AthenaLib/decorators/dataclass.py
@@ -8,11 +8,10 @@ import typing
 _T = typing.TypeVar('_T')
 
 
-def dataclass(cls, **kwargs) -> typing.Callable[[typing.Type[_T]], typing.Type[_T]]:
-    if sys.version_info >= (3, 10):
-        return dataclasses.dataclass(cls, **kwargs)
-    else:
+def dataclass(**kwargs) -> typing.Callable[[typing.Type[_T]], typing.Type[_T]]:
+    if sys.version_info < (3, 10):
         kwargs.pop('match_args', None)
         kwargs.pop('slots', None)
         kwargs.pop('kw_only', None)
-        return dataclasses.dataclass(cls, **kwargs)
+
+    return dataclasses.dataclass(**kwargs)

--- a/src/AthenaLib/models/bezier.py
+++ b/src/AthenaLib/models/bezier.py
@@ -3,12 +3,12 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-from dataclasses import dataclass
 
 # Custom Library
 
 # Custom Packages
 import AthenaLib.functions.dunder_math as dunder_math
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - All -

--- a/src/AthenaLib/models/database/mariadb.py
+++ b/src/AthenaLib/models/database/mariadb.py
@@ -5,11 +5,12 @@
 from __future__ import annotations
 import aiomysql
 import asyncio
-from dataclasses import dataclass, field
+from dataclasses import field
 
 # Custom Library
 
 # Custom Packages
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -

--- a/src/AthenaLib/models/degree.py
+++ b/src/AthenaLib/models/degree.py
@@ -3,11 +3,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-from dataclasses import dataclass
 
 # Custom Library
 
 # Custom Packages
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -

--- a/src/AthenaLib/models/vectors.py
+++ b/src/AthenaLib/models/vectors.py
@@ -3,11 +3,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-from dataclasses import dataclass
 
 # Custom Library
 
 # Custom Packages
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Vector 1D -

--- a/src/AthenaLib/models/version.py
+++ b/src/AthenaLib/models/version.py
@@ -3,11 +3,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-from dataclasses import dataclass
 
 # Custom Library
 
 # Custom Packages
+from AthenaLib.decorators.dataclass import dataclass
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -


### PR DESCRIPTION
## What changed?
- `AthenaLib.decorators.dataclass.dataclass` had a little bug
    - Bug fixed
    - Implementation simplified
- Replaced all ocurences of `dataclasses.dataclass` with `AthenaLib.decorators.dataclass.dataclass`