### PR TITLE
Fixed imports and removed dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-AthenaColor~=6.0.1

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,4 @@ if __name__ == '__main__':
         package_dir={"": "src"},
         packages=setuptools.find_packages(where="src"),
         python_requires=">=3.10",
-        install_requires=[
-            "AthenaColor>=6.2.0"
-        ]
     )

--- a/src/AthenaLib/colors/functions/blend_modes.py
+++ b/src/AthenaLib/colors/functions/blend_modes.py
@@ -10,9 +10,9 @@ from typing import Callable
 # Custom Library
 
 # Custom Packages
-from AthenaColor.models.color_system import ColorSystem, RGBA
-from AthenaColor.func.color_object_conversion import to_RGBA
-from AthenaColor.func.color_tuple_conversion import normalize_rgba
+from AthenaLib.colors.models.color_system import ColorSystem, RGBA
+from AthenaLib.colors.functions.color_object_conversion import to_RGBA
+from AthenaLib.colors.functions.color_tuple_conversion import normalize_rgba
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Support Code -

--- a/src/AthenaLib/colors/functions/color_object_conversion.py
+++ b/src/AthenaLib/colors/functions/color_object_conversion.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 # Custom Library
 
 # Custom Packages
-from AthenaColor.func.color_tuple_conversion import rgb_to_hex, rgba_to_hexa
-from AthenaColor.models.color_system import ColorSystem,RGB,HEX,CMYK,HSL,HSV,RGBA,HEXA, color_conversions_mapped
+from AthenaLib.colors.functions.color_tuple_conversion import rgb_to_hex, rgba_to_hexa
+from AthenaLib.colors.models.color_system import ColorSystem,RGB,HEX,CMYK,HSL,HSV,RGBA,HEXA, color_conversions_mapped
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - All -

--- a/src/AthenaLib/colors/functions/color_tuple_conversion.py
+++ b/src/AthenaLib/colors/functions/color_tuple_conversion.py
@@ -9,10 +9,10 @@ import math
 # Custom Library
 
 # Custom Packages
-from AthenaColor.func.general import (
+from AthenaLib.colors.functions.general import (
     round_half_up
 )
-from AthenaColor.func.constrains import (
+from AthenaLib.colors.functions.constrains import (
     constrain_hsv, constrain_hsl, constrain_rgb, constrain_cmyk, constrain_rgba
 )
 

--- a/src/AthenaLib/colors/models/color_system.py
+++ b/src/AthenaLib/colors/models/color_system.py
@@ -8,9 +8,9 @@ from typing import Tuple
 # Custom Library
 
 # Custom Packages
-import AthenaColor.func.dunder_functions as CSD
-from AthenaColor.func.color_tuple_conversion import *
-from AthenaColor.func.constrains import constrain
+import AthenaLib.colors.functions.dunder_functions as CSD
+from AthenaLib.colors.functions.color_tuple_conversion import *
+from AthenaLib.colors.functions.constrains import constrain
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - All -


### PR DESCRIPTION
imports weren't correct anymore, still trying to import from AthenaColor which doesn't have the functionality anymore.
Removed AthenaColor as a dependecy because AthenaLib now contains all functions on it's own.