### PR TITLE
Add dependency: numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,7 @@ if __name__ == '__main__':
         package_dir={"": "src"},
         packages=setuptools.find_packages(where="src"),
         python_requires=">=3.10",
+        install_requires=[
+            "numpy>=1.23.4"
+        ]
     )


### PR DESCRIPTION
There are some very huge problems with adding numpy as a dependency:
- backward-compatibility: since `1.22.0` numpy doesn't support `Python 3.7` anymore
- "forward-compatibility": numpy first provided `CPython 3.10` wheels in version `1.21.1`
- In this range of versions, only `PyPy 3.7` is supported (since version `1.22.0` only `PyPy 3.8` is supported)

The solution right now is to make it optional to install numpy via `pip install AthenaLib[math]`. Eventually there is a better solution, but i didn't find it yet.
